### PR TITLE
Add GET endpoint for UCSBOrganization

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -41,6 +41,24 @@ public class UCSBOrganizationController extends ApiController {
   }
 
   /**
+   * This method returns a single UCSBOrganization.
+   *
+   * @param orgCode organization code
+   * @return a single UCSBOrganization
+   */
+  @Operation(summary = "Get a single UCSBOrganization")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("")
+  public UCSBOrganization getById(@Parameter(name = "orgCode") @RequestParam String orgCode) {
+    UCSBOrganization organization =
+        ucsbOrganizationRepository
+            .findById(orgCode)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+    return organization;
+  }
+
+  /**
    * This method creates a new UCSBOrganization. Accessible only to users with the role
    * "ROLE_ADMIN".
    *

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -48,6 +48,13 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
   }
 
   @Test
+  public void logged_out_users_cannot_get_by_id() throws Exception {
+    mockMvc
+        .perform(get("/api/UCSBOrganization").param("orgCode", "TESTORG"))
+        .andExpect(status().is(403));
+  }
+
+  @Test
   public void logged_out_users_cannot_post() throws Exception {
     mockMvc
         .perform(
@@ -76,7 +83,65 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
   @WithMockUser(roles = {"USER"})
   @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+    // arrange
+
+    UCSBOrganization organization =
+        UCSBOrganization.builder()
+            .orgCode("TESTORG")
+            .orgTranslationShort("Test Short")
+            .orgTranslation("Test Organization")
+            .inactive(false)
+            .build();
+
+    when(ucsbOrganizationRepository.findById(eq("TESTORG"))).thenReturn(Optional.of(organization));
+
+    // act
+
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/UCSBOrganization").param("orgCode", "TESTORG"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+
+    verify(ucsbOrganizationRepository, times(1)).findById(eq("TESTORG"));
+    String expectedJson = mapper.writeValueAsString(organization);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+    // arrange
+
+    when(ucsbOrganizationRepository.findById(eq("MISSING"))).thenReturn(Optional.empty());
+
+    // act
+
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/UCSBOrganization").param("orgCode", "MISSING"))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+
+    verify(ucsbOrganizationRepository, times(1)).findById(eq("MISSING"));
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("UCSBOrganization with id MISSING not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
   public void logged_in_user_can_get_all_ucsborganizations() throws Exception {
+
+    // arrange
 
     UCSBOrganization org1 =
         UCSBOrganization.builder()
@@ -99,8 +164,12 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
     when(ucsbOrganizationRepository.findAll()).thenReturn(expectedOrganizations);
 
+    // act
+
     MvcResult response =
         mockMvc.perform(get("/api/UCSBOrganization/all")).andExpect(status().isOk()).andReturn();
+
+    // assert
 
     verify(ucsbOrganizationRepository, times(1)).findAll();
     String expectedJson = mapper.writeValueAsString(expectedOrganizations);
@@ -112,6 +181,8 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
   @Test
   public void an_admin_user_can_post_a_new_organization() throws Exception {
 
+    // arrange
+
     UCSBOrganization organization =
         UCSBOrganization.builder()
             .orgCode("TESTORG")
@@ -121,6 +192,8 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
             .build();
 
     when(ucsbOrganizationRepository.save(eq(organization))).thenReturn(organization);
+
+    // act
 
     MvcResult response =
         mockMvc
@@ -134,6 +207,8 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
             .andExpect(status().isOk())
             .andReturn();
 
+    // assert
+
     verify(ucsbOrganizationRepository, times(1)).save(organization);
     String expectedJson = mapper.writeValueAsString(organization);
     String responseString = response.getResponse().getContentAsString();
@@ -143,6 +218,8 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
   @WithMockUser(roles = {"ADMIN", "USER"})
   @Test
   public void admin_can_edit_an_existing_organization() throws Exception {
+
+    // arrange
 
     UCSBOrganization originalOrganization =
         UCSBOrganization.builder()
@@ -165,6 +242,8 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
     when(ucsbOrganizationRepository.findById(eq("TESTORG")))
         .thenReturn(Optional.of(originalOrganization));
 
+    // act
+
     MvcResult response =
         mockMvc
             .perform(
@@ -177,6 +256,8 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
             .andExpect(status().isOk())
             .andReturn();
 
+    // assert
+
     verify(ucsbOrganizationRepository, times(1)).findById("TESTORG");
     verify(ucsbOrganizationRepository, times(1)).save(originalOrganization);
     String responseString = response.getResponse().getContentAsString();
@@ -186,6 +267,8 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
   @WithMockUser(roles = {"ADMIN", "USER"})
   @Test
   public void admin_cannot_edit_organization_that_does_not_exist() throws Exception {
+
+    // arrange
 
     UCSBOrganization editedOrganization =
         UCSBOrganization.builder()
@@ -199,6 +282,8 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
     when(ucsbOrganizationRepository.findById(eq("MISSING"))).thenReturn(Optional.empty());
 
+    // act
+
     MvcResult response =
         mockMvc
             .perform(
@@ -210,6 +295,8 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                     .with(csrf()))
             .andExpect(status().isNotFound())
             .andReturn();
+
+    // assert
 
     verify(ucsbOrganizationRepository, times(1)).findById("MISSING");
     Map<String, Object> json = responseToJson(response);


### PR DESCRIPTION
Closes #16 

In this PR, we add a GET endpoint for UCSBOrganization.
<img width="1439" height="697" alt="image" src="https://github.com/user-attachments/assets/350e7cd9-3948-4b9d-91a1-1c62171cc9a4" /><img width="1439" height="379" alt="image" src="https://github.com/user-attachments/assets/7b860f30-86af-4ce5-8995-d5caeebb634e" />




Jacoco Report:
<img width="1167" height="414" alt="image" src="https://github.com/user-attachments/assets/07a43585-784b-4554-936b-0b16ab53a85d" />


Pitest Coverage:
<img width="945" height="707" alt="image" src="https://github.com/user-attachments/assets/b691c904-1045-4cc6-8f1c-205967fe48a9" />