### PR TITLE
Add DELETE endpoint for UCSBOrganization

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -41,6 +41,24 @@ public class UCSBOrganizationController extends ApiController {
   }
 
   /**
+   * This method returns a single UCSBOrganization.
+   *
+   * @param orgCode organization code
+   * @return a single UCSBOrganization
+   */
+  @Operation(summary = "Get a single UCSBOrganization")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("")
+  public UCSBOrganization getById(@Parameter(name = "orgCode") @RequestParam String orgCode) {
+    UCSBOrganization organization =
+        ucsbOrganizationRepository
+            .findById(orgCode)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+    return organization;
+  }
+
+  /**
    * This method creates a new UCSBOrganization. Accessible only to users with the role
    * "ROLE_ADMIN".
    *

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -96,5 +97,24 @@ public class UCSBOrganizationController extends ApiController {
     ucsbOrganizationRepository.save(organization);
 
     return organization;
+  }
+
+  /**
+   * Delete a UCSBOrganization. Accessible only to users with the role "ROLE_ADMIN".
+   *
+   * @param orgCode organization code
+   * @return a message indicating the organization was deleted
+   */
+  @Operation(summary = "Delete a UCSBOrganization")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @DeleteMapping("")
+  public Object deleteOrganization(@Parameter(name = "orgCode") @RequestParam String orgCode) {
+    UCSBOrganization organization =
+        ucsbOrganizationRepository
+            .findById(orgCode)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+    ucsbOrganizationRepository.delete(organization);
+    return genericMessage("UCSBOrganization with id %s deleted".formatted(orgCode));
   }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -1,11 +1,13 @@
 package edu.ucsb.cs156.example.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -138,6 +140,63 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
     String expectedJson = mapper.writeValueAsString(organization);
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_delete_an_existing_organization() throws Exception {
+
+    // arrange
+
+    UCSBOrganization organization =
+        UCSBOrganization.builder()
+            .orgCode("TESTORG")
+            .orgTranslationShort("Test Short")
+            .orgTranslation("Test Organization")
+            .inactive(false)
+            .build();
+
+    when(ucsbOrganizationRepository.findById(eq("TESTORG"))).thenReturn(Optional.of(organization));
+
+    // act
+
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/UCSBOrganization").param("orgCode", "TESTORG").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+
+    verify(ucsbOrganizationRepository, times(1)).findById("TESTORG");
+    verify(ucsbOrganizationRepository, times(1)).delete(any());
+
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("UCSBOrganization with id TESTORG deleted", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_tries_to_delete_non_existent_organization_and_gets_right_error_message()
+      throws Exception {
+
+    // arrange
+
+    when(ucsbOrganizationRepository.findById(eq("MISSING"))).thenReturn(Optional.empty());
+
+    // act
+
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/UCSBOrganization").param("orgCode", "MISSING").with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+
+    verify(ucsbOrganizationRepository, times(1)).findById("MISSING");
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("UCSBOrganization with id MISSING not found", json.get("message"));
   }
 
   @WithMockUser(roles = {"ADMIN", "USER"})

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -48,6 +48,13 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
   }
 
   @Test
+  public void logged_out_users_cannot_get_by_id() throws Exception {
+    mockMvc
+        .perform(get("/api/UCSBOrganization").param("orgCode", "TESTORG"))
+        .andExpect(status().is(403));
+  }
+
+  @Test
   public void logged_out_users_cannot_post() throws Exception {
     mockMvc
         .perform(
@@ -76,7 +83,65 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
   @WithMockUser(roles = {"USER"})
   @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+    // arrange
+
+    UCSBOrganization organization =
+        UCSBOrganization.builder()
+            .orgCode("TESTORG")
+            .orgTranslationShort("Test Short")
+            .orgTranslation("Test Organization")
+            .inactive(false)
+            .build();
+
+    when(ucsbOrganizationRepository.findById(eq("TESTORG"))).thenReturn(Optional.of(organization));
+
+    // act
+
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/UCSBOrganization").param("orgCode", "TESTORG"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+
+    verify(ucsbOrganizationRepository, times(1)).findById(eq("TESTORG"));
+    String expectedJson = mapper.writeValueAsString(organization);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+    // arrange
+
+    when(ucsbOrganizationRepository.findById(eq("MISSING"))).thenReturn(Optional.empty());
+
+    // act
+
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/UCSBOrganization").param("orgCode", "MISSING"))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+
+    verify(ucsbOrganizationRepository, times(1)).findById(eq("MISSING"));
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("UCSBOrganization with id MISSING not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
   public void logged_in_user_can_get_all_ucsborganizations() throws Exception {
+
+    // arrange
 
     UCSBOrganization org1 =
         UCSBOrganization.builder()
@@ -99,8 +164,12 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
     when(ucsbOrganizationRepository.findAll()).thenReturn(expectedOrganizations);
 
+    // act
+
     MvcResult response =
         mockMvc.perform(get("/api/UCSBOrganization/all")).andExpect(status().isOk()).andReturn();
+
+    // assert
 
     verify(ucsbOrganizationRepository, times(1)).findAll();
     String expectedJson = mapper.writeValueAsString(expectedOrganizations);
@@ -112,6 +181,8 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
   @Test
   public void an_admin_user_can_post_a_new_organization() throws Exception {
 
+    // arrange
+
     UCSBOrganization organization =
         UCSBOrganization.builder()
             .orgCode("TESTORG")
@@ -121,6 +192,8 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
             .build();
 
     when(ucsbOrganizationRepository.save(eq(organization))).thenReturn(organization);
+
+    // act
 
     MvcResult response =
         mockMvc
@@ -134,6 +207,8 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
             .andExpect(status().isOk())
             .andReturn();
 
+    // assert
+
     verify(ucsbOrganizationRepository, times(1)).save(organization);
     String expectedJson = mapper.writeValueAsString(organization);
     String responseString = response.getResponse().getContentAsString();
@@ -143,6 +218,8 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
   @WithMockUser(roles = {"ADMIN", "USER"})
   @Test
   public void admin_can_edit_an_existing_organization() throws Exception {
+
+    // arrange
 
     UCSBOrganization originalOrganization =
         UCSBOrganization.builder()
@@ -165,6 +242,8 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
     when(ucsbOrganizationRepository.findById(eq("TESTORG")))
         .thenReturn(Optional.of(originalOrganization));
 
+    // act
+
     MvcResult response =
         mockMvc
             .perform(
@@ -177,6 +256,8 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
             .andExpect(status().isOk())
             .andReturn();
 
+    // assert
+
     verify(ucsbOrganizationRepository, times(1)).findById("TESTORG");
     verify(ucsbOrganizationRepository, times(1)).save(originalOrganization);
     String responseString = response.getResponse().getContentAsString();
@@ -186,6 +267,8 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
   @WithMockUser(roles = {"ADMIN", "USER"})
   @Test
   public void admin_cannot_edit_organization_that_does_not_exist() throws Exception {
+
+    // arrange
 
     UCSBOrganization editedOrganization =
         UCSBOrganization.builder()
@@ -199,6 +282,8 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
     when(ucsbOrganizationRepository.findById(eq("MISSING"))).thenReturn(Optional.empty());
 
+    // act
+
     MvcResult response =
         mockMvc
             .perform(
@@ -210,6 +295,8 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                     .with(csrf()))
             .andExpect(status().isNotFound())
             .andReturn();
+
+    // assert
 
     verify(ucsbOrganizationRepository, times(1)).findById("MISSING");
     Map<String, Object> json = responseToJson(response);


### PR DESCRIPTION
Closes #18 

In this PR, we add a DELETE endpoint for UCSBOrganization.
<img width="1430" height="680" alt="image" src="https://github.com/user-attachments/assets/e25a9b09-e6ef-4fdf-92f8-5657d5b4e1d3" /><img width="1430" height="475" alt="image" src="https://github.com/user-attachments/assets/f9a3bab2-cc6d-46d1-97d6-98407eeb1bc5" />





Jacoco Report:
<img width="1193" height="341" alt="image" src="https://github.com/user-attachments/assets/3ae65239-08cf-4313-81bd-2e4b22f308e5" />


Pitest Coverage:
<img width="942" height="711" alt="image" src="https://github.com/user-attachments/assets/578332e2-01bb-4551-8e06-ab20c197b8c2" />
